### PR TITLE
Remove github-corner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,6 +1962,15 @@
             "@webcomponents/shadycss": "^1.5.2"
           }
         },
+        "@vaadin/router": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.7.4.tgz",
+          "integrity": "sha512-B4JVtzFVUMlsjuJHNXEMfNZrM4QDrdeOMc6EEigiHYxwF82py6yDdP6SWP0aPoP3f6aQHt51tLWdXSpkKpWf7A==",
+          "requires": {
+            "@vaadin/vaadin-usage-statistics": "^2.1.0",
+            "path-to-regexp": "2.4.0"
+          }
+        },
         "@vaadin/vaadin-accordion": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@vaadin/vaadin-accordion/-/vaadin-accordion-1.2.0.tgz",
@@ -2105,6 +2114,21 @@
             "@vaadin/vaadin-overlay": "^3.5.0",
             "@vaadin/vaadin-text-field": "^2.8.0",
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
+          },
+          "dependencies": {
+            "@polymer/polymer": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.4.1.tgz",
+              "integrity": "sha512-KPWnhDZibtqKrUz7enIPOiO4ZQoJNOuLwqrhV2MXzIt3VVnUVJVG5ORz4Z2sgO+UZ+/UZnPD0jqY+jmw/+a9mQ==",
+              "requires": {
+                "@webcomponents/shadycss": "^1.9.1"
+              }
+            },
+            "@webcomponents/shadycss": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+              "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
+            }
           }
         },
         "@vaadin/vaadin-date-time-picker": {
@@ -2288,6 +2312,14 @@
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
           }
         },
+        "@vaadin/vaadin-messages": {
+          "version": "20.0.1",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-messages/-/vaadin-messages-20.0.1.tgz",
+          "integrity": "sha512-7b6K2+iYZpW4fjwXTBJCJMEU22aOUR8GA1yfuvo8Vf+lh/Kt2Ma2qs37SZG6+z8Vh41H0qGKcZlGebIEQ1ByGA==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
         "@vaadin/vaadin-notification": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/@vaadin/vaadin-notification/-/vaadin-notification-1.6.1.tgz",
@@ -2322,17 +2354,6 @@
             "@vaadin/vaadin-lumo-styles": "^1.3.0",
             "@vaadin/vaadin-material-styles": "^1.2.0",
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
-          },
-          "dependencies": {
-            "@vaadin/vaadin-themable-mixin": {
-              "version": "1.6.1",
-              "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.6.1.tgz",
-              "integrity": "sha512-UXjOlEfMEk/QxpBjpiO0QTjPOSiO88bhhtV+0UTfpqk8ILvJYO+6vbwcja33xY5Wi9sTAXtHixAjM0LthyXglQ==",
-              "requires": {
-                "@polymer/polymer": "^3.0.0",
-                "lit-element": "^2.0.0"
-              }
-            }
           }
         },
         "@vaadin/vaadin-progress-bar": {
@@ -2378,6 +2399,21 @@
             "@vaadin/vaadin-overlay": "^3.5.0",
             "@vaadin/vaadin-text-field": "^2.8.0",
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
+          },
+          "dependencies": {
+            "@polymer/polymer": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.4.1.tgz",
+              "integrity": "sha512-KPWnhDZibtqKrUz7enIPOiO4ZQoJNOuLwqrhV2MXzIt3VVnUVJVG5ORz4Z2sgO+UZ+/UZnPD0jqY+jmw/+a9mQ==",
+              "requires": {
+                "@webcomponents/shadycss": "^1.9.1"
+              }
+            },
+            "@webcomponents/shadycss": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+              "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
+            }
           }
         },
         "@vaadin/vaadin-split-layout": {
@@ -2485,6 +2521,11 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
           "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA=="
+        },
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
         }
       }
     },
@@ -3023,6 +3064,15 @@
             "@webcomponents/shadycss": "^1.5.2"
           }
         },
+        "@vaadin/router": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.7.4.tgz",
+          "integrity": "sha512-B4JVtzFVUMlsjuJHNXEMfNZrM4QDrdeOMc6EEigiHYxwF82py6yDdP6SWP0aPoP3f6aQHt51tLWdXSpkKpWf7A==",
+          "requires": {
+            "@vaadin/vaadin-usage-statistics": "^2.1.0",
+            "path-to-regexp": "2.4.0"
+          }
+        },
         "@vaadin/vaadin-accordion": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@vaadin/vaadin-accordion/-/vaadin-accordion-1.2.0.tgz",
@@ -3239,6 +3289,21 @@
             "@vaadin/vaadin-overlay": "^3.5.0",
             "@vaadin/vaadin-text-field": "^2.8.0",
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
+          },
+          "dependencies": {
+            "@polymer/polymer": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.4.1.tgz",
+              "integrity": "sha512-KPWnhDZibtqKrUz7enIPOiO4ZQoJNOuLwqrhV2MXzIt3VVnUVJVG5ORz4Z2sgO+UZ+/UZnPD0jqY+jmw/+a9mQ==",
+              "requires": {
+                "@webcomponents/shadycss": "^1.9.1"
+              }
+            },
+            "@webcomponents/shadycss": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+              "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
+            }
           }
         },
         "@vaadin/vaadin-date-time-picker": {
@@ -3449,6 +3514,14 @@
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
           }
         },
+        "@vaadin/vaadin-messages": {
+          "version": "20.0.1",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-messages/-/vaadin-messages-20.0.1.tgz",
+          "integrity": "sha512-7b6K2+iYZpW4fjwXTBJCJMEU22aOUR8GA1yfuvo8Vf+lh/Kt2Ma2qs37SZG6+z8Vh41H0qGKcZlGebIEQ1ByGA==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
         "@vaadin/vaadin-notification": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/@vaadin/vaadin-notification/-/vaadin-notification-1.6.1.tgz",
@@ -3483,17 +3556,6 @@
             "@vaadin/vaadin-lumo-styles": "^1.3.0",
             "@vaadin/vaadin-material-styles": "^1.2.0",
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
-          },
-          "dependencies": {
-            "@vaadin/vaadin-themable-mixin": {
-              "version": "1.6.1",
-              "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.6.1.tgz",
-              "integrity": "sha512-UXjOlEfMEk/QxpBjpiO0QTjPOSiO88bhhtV+0UTfpqk8ILvJYO+6vbwcja33xY5Wi9sTAXtHixAjM0LthyXglQ==",
-              "requires": {
-                "@polymer/polymer": "^3.0.0",
-                "lit-element": "^2.0.0"
-              }
-            }
           }
         },
         "@vaadin/vaadin-progress-bar": {
@@ -3535,24 +3597,6 @@
             "@vaadin/vaadin-material-styles": "^1.3.2",
             "@vaadin/vaadin-text-field": "^2.7.0",
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
-          },
-          "dependencies": {
-            "@vaadin/vaadin-confirm-dialog": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/@vaadin/vaadin-confirm-dialog/-/vaadin-confirm-dialog-1.3.0.tgz",
-              "integrity": "sha512-di4hp8Ca0mGoNVDWqI9Gl/G2TXl/cKfy+ApR5co+m95+uC7wpGeocQMWuqaoTZfOmR/VqMVDveew2GhUUsELnw==",
-              "requires": {
-                "@polymer/polymer": "^3.0.0",
-                "@vaadin/vaadin-button": "^2.4.0",
-                "@vaadin/vaadin-dialog": "^2.5.0",
-                "@vaadin/vaadin-element-mixin": "^2.4.1",
-                "@vaadin/vaadin-license-checker": "^2.1.0",
-                "@vaadin/vaadin-lumo-styles": "^1.6.0",
-                "@vaadin/vaadin-material-styles": "^1.3.0",
-                "@vaadin/vaadin-overlay": "^3.5.0",
-                "@vaadin/vaadin-themable-mixin": "^1.6.1"
-              }
-            }
           }
         },
         "@vaadin/vaadin-select": {
@@ -3573,6 +3617,21 @@
             "@vaadin/vaadin-overlay": "^3.5.0",
             "@vaadin/vaadin-text-field": "^2.8.0",
             "@vaadin/vaadin-themable-mixin": "^1.6.1"
+          },
+          "dependencies": {
+            "@polymer/polymer": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.4.1.tgz",
+              "integrity": "sha512-KPWnhDZibtqKrUz7enIPOiO4ZQoJNOuLwqrhV2MXzIt3VVnUVJVG5ORz4Z2sgO+UZ+/UZnPD0jqY+jmw/+a9mQ==",
+              "requires": {
+                "@webcomponents/shadycss": "^1.9.1"
+              }
+            },
+            "@webcomponents/shadycss": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+              "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
+            }
           }
         },
         "@vaadin/vaadin-split-layout": {
@@ -3690,6 +3749,11 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
           "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA=="
+        },
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
         }
       }
     },
@@ -5946,11 +6010,6 @@
         }
       }
     },
-    "create-element-class": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/create-element-class/-/create-element-class-1.0.1.tgz",
-      "integrity": "sha1-Kx9Zzc9fyClNByWvRd9sPh6Nrg4="
-    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -7229,14 +7288,6 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
-    },
-    "github-corner": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/github-corner/-/github-corner-2.0.3.tgz",
-      "integrity": "sha1-lQzI1TTNO2l2vYSs1Nwc3yp7NyU=",
-      "requires": {
-        "create-element-class": "^1.0.1"
-      }
     },
     "glob": {
       "version": "7.1.7",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "@xpertsea/paper-slider": "3.0.0",
     "construct-style-sheets-polyfill": "2.4.16",
-    "github-corner": "2.0.3",
     "lit-element": "2.5.1",
     "lit-html": "1.4.1"
   },
@@ -140,6 +139,6 @@
       "webpack-dev-server": "3.11.0",
       "webpack-merge": "4.2.2"
     },
-    "hash": "d35d9e111bcb418f5c0a820237491ff8da9e14cdb1dfb334c77a893f57258875"
+    "hash": "63dd9afc1e39f03460345d3b61d4ef42f9d426c24ca3294068b077bc80ebe929"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.vaadin.artur</groupId>
-            <artifactId>github-corner</artifactId>
-            <version>2.0.3</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.vaadin.addons</groupId>
             <artifactId>googleanalyticstracker</artifactId>
             <version>4.0.0</version>

--- a/src/main/java/com/vaadin/demo/AppNavLayout.java
+++ b/src/main/java/com/vaadin/demo/AppNavLayout.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.vaadin.flow.component.tabs.TabsVariant;
-import org.vaadin.artur.github_corner.GitHubCorner;
 
 import com.vaadin.demo.views.IntroView;
 import com.vaadin.flow.component.Component;
@@ -28,7 +27,6 @@ public class AppNavLayout extends AppLayout implements AfterNavigationObserver {
         getElement().getThemeList().add("app-nav-layout");
         menu = createMenuTabs();
         addToNavbar(menu);
-        addToNavbar(new GitHubCorner("vaadin", "layout-examples"));
     }
 
     private static Tabs createMenuTabs() {


### PR DESCRIPTION
github-corner is causing an error as it still depends on vaadin-bom 14.0.0.beta2

```
[ERROR] Failed to execute goal on project layout-examples: Could not resolve dependencies for project com.vaadin.demo:layout-examples:war:1.0-SNAPSHOT: Failed to collect dependencies at org.vaadin.artur:github-corner:jar:2.0.3: Failed to read artif
act descriptor for org.vaadin.artur:github-corner:jar:2.0.3: Could not transfer artifact com.vaadin:vaadin-bom:pom:14.0.0.beta2 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [Vaadin Directory (http://maven.v
aadin.com/vaadin-addons, default, releases+snapshots), Vaadin prereleases (http://maven.vaadin.com/vaadin-prereleases, default, releases+snapshots)] -> [Help 1]
```